### PR TITLE
Throw meaningful `ArgumentException` for inconsistent source data

### DIFF
--- a/ChronoJsonDiffPatch/ChronoJsonDiffPatch/TimeRangePatchChain.cs
+++ b/ChronoJsonDiffPatch/ChronoJsonDiffPatch/TimeRangePatchChain.cs
@@ -75,7 +75,23 @@ public class TimeRangePatchChain<TEntity> : TimePeriodChain
             return new List<TimeRangePatch>();
         }
 
-        return timeperiods.OrderBy(tp => tp.Start);
+        var result = timeperiods.OrderBy(tp => tp.Start);
+        var ambigousStarts = result.GroupBy(tp => tp.To).Where(g => g.Count() > 1).Select(g => g.Select(x => x.Start).Distinct());
+        var ambigousEnds = result.GroupBy(tp => tp.End).Where(g => g.Count() > 1).Select(g => g.Select(x => x.End).Distinct()); ;
+        bool baseConstructorIsLikelyToCrash = ambigousStarts.Any() || ambigousEnds.Any();
+        if (baseConstructorIsLikelyToCrash)
+        {
+            try
+            {
+                _ = new TimePeriodChain(result); // a test if the base constructor will actually crash?
+            }
+            catch (InvalidOperationException invalidOpException) when (invalidOpException.Message.EndsWith("out of range"))
+            {
+                // if it would crash and we do know the reasons, then we throw a more meaningful exception here instead of waiting for the base class to crash
+                throw new ArgumentException($"The given periods contain ambiguous starts ({ambigousStarts}) or ends ({ambigousEnds})", innerException: invalidOpException);
+            }
+        }
+        return result;
     }
 
     /// <summary>


### PR DESCRIPTION
instead of hard to understand exception from base class
